### PR TITLE
Fix privilege set for read only collection

### DIFF
--- a/radicale/xmlutils.py
+++ b/radicale/xmlutils.py
@@ -45,7 +45,7 @@ except ImportError:
 import re
 import xml.etree.ElementTree as ET
 
-from . import client, config, ical
+from . import client, config, ical, rights
 
 
 NAMESPACES = {
@@ -300,11 +300,13 @@ def _propfind_response(path, item, props, user):
             element.append(tag)
         elif tag == _tag("D", "current-user-privilege-set"):
             privilege = ET.Element(_tag("D", "privilege"))
-            privilege.append(ET.Element(_tag("D", "all")))
+            if rights.authorized(user, item, "w"):
+                privilege.append(ET.Element(_tag("D", "all")))
             privilege.append(ET.Element(_tag("D", "read")))
-            privilege.append(ET.Element(_tag("D", "write")))
-            privilege.append(ET.Element(_tag("D", "write-properties")))
-            privilege.append(ET.Element(_tag("D", "write-content")))
+            if rights.authorized(user, item, "w"):
+                privilege.append(ET.Element(_tag("D", "write")))
+                privilege.append(ET.Element(_tag("D", "write-properties")))
+                privilege.append(ET.Element(_tag("D", "write-content")))
             element.append(privilege)
         elif tag == _tag("D", "supported-report-set"):
             for report_name in (


### PR DESCRIPTION
When server responses to PROPFIND request for a collection it doesn't check access rights for the collection and send full set of privileges: all, read, write, write-properties, write-content. This patch add rights check and server will response accordingly.
